### PR TITLE
Clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -106,8 +103,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-emqx.svg
 [commits]: https://github.com/hassio-addons/addon-emqx/commits/main
 [contributors]: https://github.com/hassio-addons/addon-emqx/graphs/contributors
@@ -123,7 +118,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-emqx/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-emqx/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-emqx.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg


### PR DESCRIPTION
# Proposed Changes

Removes architecure no longer used by Home Assistant from the README


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported architectures documentation by simplifying the displayed platform list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->