### PR TITLE
Update link to EMQX documentation.

### DIFF
--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -70,7 +70,7 @@ start of this chapter to get an idea of how the configuration looks.
 For more information about using these variables, see the official EMQX
 documentation:
 
-<https://www.emqx.io/docs/en/v5.0/admin/cfg.html>
+<https://docs.emqx.com/en/emqx/v5.10/configuration/configuration.html#environment-variables>
 
 **Note**: _Only environment variables starting with `EMQX_` are accepted.\_
 


### PR DESCRIPTION
# Proposed Changes

> Existing link to documentation regarding environment variables is stale.  Changed to point to latest v5 version of EMQX documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `env_vars` guidance to point to the current EMQX environment variables documentation page.
  * Replaced an outdated reference with the latest official documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->