### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,8 +24,8 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_12/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     },
     {
       "customType": "regex",
@@ -37,7 +37,12 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {

--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/finish
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/finish
@@ -4,8 +4,9 @@
 # Home Assistant Community Add-on: EMQX
 # Take down the S6 supervision tree when EMQX fails
 # ==============================================================================
-declare exit_code
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+declare exit_code_container
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="EMQX"
@@ -16,7 +17,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo $((128 + exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -6,7 +6,9 @@
 # ==============================================================================
 bashio::log.info 'Starting EMQX...'
 
-export EMQX_HOST=$(bashio::info.hostname)
+EMQX_HOST=$(bashio::info.hostname)
+
+export EMQX_HOST
 export EMQX_NAME="emqx"
 export EMQX_NODE__COOKIE="${EMQX_HOST}"
 export EMQX_NODE__DATA_DIR="/data/emqx/data"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names, and to hardcode the Debian release into the `depNameTemplate`.

That hardcoded release is stale here. The template says `debian_12/{{package}}`, but this add-on has been on Debian 13 (trixie) since the base image moved to `ghcr.io/hassio-addons/debian-base` v8 in #150. Repology has therefore been comparing our `procps` pin against the bookworm version (`2:4.0.2-3`), which is older than what we pin (`2:4.0.4-9`), so the pin was silently frozen and has never received an update proposal.

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and both the name mapping and the hardcoded release disappear.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`. Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

The practical impact here is nil: `procps` is the only apt pin in this add-on, and it resolves from `trixie` `main`.

Validated with `renovate-config-validator` from Renovate 44.46.4.

### Also in here: Shellcheck

CI was already red on `main` over four Shellcheck findings in the s6 service scripts. They are unrelated to the Renovate change, but they block this PR from going green, so the second commit clears them:

* `SC2155` in `run`: `export EMQX_HOST=$(...)` masks the exit status of the command substitution, so a failing `bashio::info.hostname` would pass unnoticed. Assign first, export after.
* `SC2034` in `finish`: `declare exit_code` names a variable that is never used. The one actually in use is `exit_code_container`.
* `SC2155` in `finish`: the same masking problem on `exit_code_container`.
* `SC2004` in `finish`: `$exit_code_signal` does not need the sigil inside an arithmetic expansion.

Both scripts now match how the other add-ons in the family write them. Verified locally with `koalaman/shellcheck:stable` and `SHELLCHECK_OPTS=-s bash`, matching CI.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Same change as hassio-addons/app-vaultwarden#447, which has the full reasoning.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
