### PR TITLE
Update EMQX to 6.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-The most scalable open-source MQTT broker for IoT, IIoT, and connected vehicles.
+The most scalable MQTT broker for IoT, IIoT, and connected vehicles.
 
 ![EMQX in the Home Assistant Frontend](images/screenshot.png)
 
 ## About
 
-[EMQX][emqx] is an Open-source MQTT broker with a high-performance real-time
-message processing engine, powering event streaming for IoT devices at massive
-scale. As the most scalable MQTT broker, EMQX can help you connect any device,
-at any scale (including your home).
+[EMQX][emqx] is an MQTT broker with a high-performance real-time message
+processing engine, powering event streaming for IoT devices at massive scale.
+As the most scalable MQTT broker, EMQX can help you connect any device, at any
+scale (including your home).
 
 The [EMQX MQTT broker][emqx] is an advanced alternative to the Mosquitto MQTT
 broker/app that is generally used in Home Assistant. It has a UI
@@ -29,6 +29,12 @@ to configure, manage, and debug your MQTT broker, clients, and traffic.
 
 While EMQX sells their product mainly as a cloud hosted product on their
 website, this app runs EMQX in a fully local, self-hosted environment.
+
+As of version 5.9.0, EMQX is no longer open source; it is licensed under the
+[Business Source License 1.1][emqx-license]. The build shipped here carries the
+EMQX Community License, which is free of charge and allows running a single
+node, which is exactly what this app does. Clustering requires a commercial
+license.
 
 [:books: Read the full app documentation][docs]
 
@@ -101,6 +107,7 @@ SOFTWARE.
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [docs]: https://github.com/hassio-addons/app-emqx/blob/main/emqx/DOCS.md
+[emqx-license]: https://github.com/emqx/emqx/blob/main/LICENSE
 [emqx]: https://www.emqx.io/
 [forum]: https://community.home-assistant.io/?u=frenck
 [frenck]: https://github.com/frenck

--- a/emqx/.README.j2
+++ b/emqx/.README.j2
@@ -6,14 +6,14 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-The most scalable open-source MQTT broker for IoT, IIoT, and connected vehicles.
+The most scalable MQTT broker for IoT, IIoT, and connected vehicles.
 
 ## About
 
-[EMQX][emqx] is an Open-source MQTT broker with a high-performance real-time
-message processing engine, powering event streaming for IoT devices at massive
-scale. As the most scalable MQTT broker, EMQX can help you connect any device,
-at any scale (including your home).
+[EMQX][emqx] is an MQTT broker with a high-performance real-time message
+processing engine, powering event streaming for IoT devices at massive scale.
+As the most scalable MQTT broker, EMQX can help you connect any device, at any
+scale (including your home).
 
 The [EMQX MQTT broker][emqx] is an advanced alternative to the Mosquitto MQTT
 broker/app that is generally used in Home Assistant. It has a UI
@@ -21,6 +21,12 @@ to configure, manage, and debug your MQTT broker, clients, and traffic.
 
 While EMQX sells their product mainly as a cloud hosted product on their
 website, this app runs EMQX in a fully local, self-hosted environment.
+
+As of version 5.9.0, EMQX is no longer open source; it is licensed under the
+[Business Source License 1.1][emqx-license]. The build shipped here carries the
+EMQX Community License, which is free of charge and allows running a single
+node, which is exactly what this app does. Clustering requires a commercial
+license.
 
 ![EMQX in the Home Assistant Frontend][screenshot]
 
@@ -63,6 +69,7 @@ If you are more interested in stable releases of our apps:
 <https://github.com/hassio-addons/repository>
 
 {% endif %}
+[emqx-license]: https://github.com/emqx/emqx/blob/main/LICENSE
 [emqx]: https://www.emqx.io/
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck

--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -1,9 +1,9 @@
 # Home Assistant Community App: EMQX
 
-[EMQX][emqx] is an Open-source MQTT broker with a high-performance real-time
-message processing engine, powering event streaming for IoT devices at massive
-scale. As the most scalable MQTT broker, EMQX can help you connect any device,
-at any scale (including your home).
+[EMQX][emqx] is an MQTT broker with a high-performance real-time message
+processing engine, powering event streaming for IoT devices at massive scale.
+As the most scalable MQTT broker, EMQX can help you connect any device, at any
+scale (including your home).
 
 The [EMQX MQTT broker][emqx] is an advanced alternative to the Mosquitto MQTT
 broker/app that is generally used in Home Assistant. It has a UI
@@ -11,6 +11,12 @@ to configure, manage, and debug your MQTT broker, clients, and traffic.
 
 While EMQX sells their product mainly as a cloud hosted product on their
 website, this app runs EMQX in a fully local, self-hosted environment.
+
+As of version 5.9.0, EMQX is no longer open source; it is licensed under the
+[Business Source License 1.1][emqx-license]. The build shipped here carries the
+EMQX Community License, which is free of charge and allows running a single
+node, which is exactly what this app does. Clustering requires a commercial
+license.
 
 ## Installation
 
@@ -70,7 +76,7 @@ start of this chapter to get an idea of how the configuration looks.
 For more information about using these variables, see the official EMQX
 documentation:
 
-<https://docs.emqx.com/en/emqx/v5.10/configuration/configuration.html#environment-variables>
+<https://docs.emqx.com/en/emqx/v6.2/configuration/configuration.html#environment-variables>
 
 **Note**: _Only environment variables starting with `EMQX_` are accepted.\_
 
@@ -86,6 +92,18 @@ documentation:
   port 8083. Temporary disabling the integration (similar as the point above
   for apps) can be used to allow accessing the EMQX web UI to adjust the
   listeners.
+
+## Upgrading from EMQX 5
+
+This app has moved from EMQX 5.8.9 to EMQX 6. EMQX 6 reads the existing data
+directory in place, so dashboard users, authentication records, rules and
+retained messages carry over on the first start, and there is nothing to do
+beyond updating the app.
+
+A major version change is still a good moment for a backup. Downgrading back to
+EMQX 5 is not something EMQX supports, so take one before updating if you want a
+way back. The app data lives in `/data/emqx`, which the Home Assistant backup of
+this app covers.
 
 ## Changelog & Releases
 
@@ -151,6 +169,7 @@ SOFTWARE.
 [contributors]: https://github.com/hassio-addons/app-emqx/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
+[emqx-license]: https://github.com/emqx/emqx/blob/main/LICENSE
 [emqx]: https://www.emqx.io/
 [forum]: https://community.home-assistant.io/?u=frenck
 [frenck]: https://github.com/frenck

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG EMQX_VERSION="v5.8.9"
+ARG EMQX_VERSION="6.2.3"
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -17,8 +17,8 @@ RUN \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     && curl -L -s \
-        "https://github.com/emqx/emqx/releases/download/${EMQX_VERSION}/emqx-${EMQX_VERSION#v}-debian13-${ARCH}.tar.gz" \
-        | tar zxvf - -C /opt/emqx \
+        "https://packages.emqx.io/emqx-ee/${EMQX_VERSION}/emqx-enterprise-${EMQX_VERSION}-debian13-${ARCH}.tar.gz" \
+        | tar zxf - -C /opt/emqx \
     && rm -fr \
         /opt/emqx/log \
         /var/{cache,log}/* \

--- a/emqx/config.yaml
+++ b/emqx/config.yaml
@@ -2,7 +2,7 @@
 name: EMQX
 version: dev
 slug: emqx
-description: The most scalable open-source MQTT broker for IoT. An alternative for the Mosquitto app
+description: The most scalable MQTT broker for IoT. An alternative for the Mosquitto app
 url: https://github.com/hassio-addons/app-emqx
 startup: services
 ingress: true


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Moves the app to **EMQX 6.2.3**, replacing #158.

### Why #158 could not work as it stood

It changed the version and nothing else, but everything about EMQX packaging moved in 6.x:

| | 5.8.9 | 6.2.3 |
| --- | --- | --- |
| Tag | `v5.8.9` | `6.2.3` |
| Tarball | `emqx-5.8.9-debian13-amd64.tar.gz` | `emqx-enterprise-6.2.3-debian13-amd64.tar.gz` |
| Distribution | EMQX (open source) | EMQX Enterprise, single distribution |

So the URL #158 produced 404s. Worse, the version it picked has **no GitHub release assets at all**:

```
$ gh api repos/emqx/emqx/releases/tags/6.2.3 -q '.assets | length'
0
$ gh api repos/emqx/emqx/releases/tags/6.1.4 -q '.assets | length'
0
```

That is not a one off. EMQX publishes tags and release notes on GitHub but uploads the binaries inconsistently, so any Renovate bump can land on a version that cannot be downloaded. Every one of those versions **is** on the vendor package host:

```
200  packages.emqx.io/emqx-ee/6.2.3/{amd64,arm64}
200  packages.emqx.io/emqx-ee/6.1.4/{amd64,arm64}
404  github.com/emqx/emqx/releases/download/6.2.3/...
```

The download therefore moves to `packages.emqx.io`, which is where `emqx.com/en/downloads` redirects anyway. Renovate keeps using GitHub releases to discover versions, since the tags are reliable even when the assets are not; this change is what decouples the two.

`tar` also loses its `v` flag. Unpacking EMQX was listing several thousand file names into the build log.

### :warning: EMQX is no longer open source

This is the part worth a decision rather than a review nod.

As of **5.9.0**, EMQX relicensed from Apache 2.0 to the [Business Source License 1.1](https://github.com/emqx/emqx/blob/main/LICENSE). There is no open source edition any more; the community and enterprise builds merged into one. 5.8.9, what we ship today, is the last Apache 2.0 release, and it is end of line.

What the shipped build actually does, confirmed by running it:

```
You are currently using the EMQX Community License included with this software.
Permitted Use: Free use of a single node in your internal environment.
What Requires a Different License:
 - Clustered deployments (more than one node).
 - Commercial use in SaaS, hosted services, or embedded/resold products.
```

In the source, that Community License is `ltype=community`, single node, **10,000,000 sessions** (`DEFAULT_MAX_SESSIONS_LTYPE2`), no expiry. So for a Home Assistant user nothing is gated: one node, no practical session cap, no key to enter, no trial clock. Only clustering is off the table, and this app has never clustered.

The part that needs your judgement is upstream of that. The BSL Additional Use Grant permits production use of a single node "provided your use does not include offering the Licensed Work to third parties on a hosted or embedded basis", where embedded means "integrating it into a product or solution offered to third parties". The licence separately grants the right to redistribute. Each user running one node at home sits squarely inside the grant. Whether publishing a prebuilt image that bundles EMQX reads as redistribution (granted) or as embedding it in something offered to third parties (not granted) is a call for you, not for me, and it is not affected by the fact that this app is free.

Documentation is updated either way: the tagline, the About sections and `config.yaml` no longer call EMQX open source, and DOCS.md states the licence plainly.

### Verified

Both versions built for amd64 against `debian-base:9.4.0` and actually run, rather than just building:

- **6.2.3 fresh start.** All listeners up, dashboard on 18083, `EMQX Enterprise 6.2.3 is running now!`.
- **In-place upgrade 5.8.9 → 6.2.3.** Started 5.8.9 on an empty `/data`, created a dashboard user, stopped it, then started 6.2.3 on the same directory. It came up on the existing `mnesia/emqx@127.0.0.1` with no migration step, and the user created under 5.8.9 authenticates against the 6.2.3 dashboard API:

  ```
  $ curl -X POST /api/v5/login -d '{"username":"hatest","password":"hatestpass123"}'
  {"version":"6.2.3","token":"...","role":"administrator","license":{"edition":"ee"}}
  ```

  `admin` / `public` still works too, so the documented first login is unchanged.
- **Downgrade.** DOCS.md says to take a backup because EMQX does not support going back. For the record, 5.8.9 did still start on a directory 6.2.3 had run on in my test, so this is a caution rather than a wall.
- All the environment variables the run script sets are still honoured; EMQX echoes them at boot. `node.etc_dir` is still in the 6.2.3 schema.
- Prettier, YAMLLint and Hadolint clean.

### Not taken from #164

#164 bundles this bump with a fix for #161, a rewrite of the About text into inline links, an `EMQX_NODE__COOKIE` change, and a 238 line bespoke CI harness. The #161 fix is worth having and is proposed separately so it can be judged on its own; the rest is left out of this one deliberately.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Replaces #158. Supersedes the version bump half of #164.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled EMQX version to 6.2.3.
  * Added guidance for EMQX 5-to-6 upgrades and data migration.
* **Documentation**
  * Clarified EMQX licensing, including Community License single-node limitations and commercial clustering requirements.
  * Updated environment-variable documentation links.
* **Chores**
  * Updated the package source to the EMQX enterprise repository.
  * Refreshed the add-on description to reflect current licensing terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->