### PR TITLE
Keep the EMQX node name stable across hostname changes

### DIFF
--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -92,8 +92,10 @@ You do not need to configure anything. If you want a specific name anyway, set
 
 If a hostname change already left you with more than one database directory
 under `/data/emqx/data/mnesia`, this app cannot tell which one you meant to
-keep. It logs the names it found and carries on with one of them; set
-`EMQX_NODE__NAME` to the one you want, or use
+keep. It logs the names it found and then falls back to the name matching your
+current hostname, or to `emqx@127.0.0.1` when none of them match. That fallback
+is an empty database, so EMQX will look freshly installed. Set
+`EMQX_NODE__NAME` to the directory you want and restart, or use
 [EMQX backup and restore][backup-restore] to merge them.
 
 ## Known issues and limitations

--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -56,7 +56,7 @@ Example app configuration:
 ```yaml
 env_vars:
   - name: EMQX_NODE__NAME
-    value: "something@else.local"
+    value: "emqx@stable.example"
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -73,6 +73,28 @@ documentation:
 <https://docs.emqx.com/en/emqx/v5.10/configuration/configuration.html#environment-variables>
 
 **Note**: _Only environment variables starting with `EMQX_` are accepted.\_
+
+### The EMQX node name
+
+EMQX stores its database in a directory named after its node name, and this app
+used to derive that name from the Home Assistant hostname. Renaming your Home
+Assistant instance therefore pointed EMQX at a fresh, empty database, leaving
+the old one on disk but out of reach.
+
+The node name is now decided once and kept in `/data/emqx/node.name`:
+
+- A new installation uses `emqx@127.0.0.1`.
+- An existing installation keeps the name its database already carries, so
+  nothing moves when you update.
+
+You do not need to configure anything. If you want a specific name anyway, set
+`EMQX_NODE__NAME` through `env_vars` and it wins over both of the above.
+
+If a hostname change already left you with more than one database directory
+under `/data/emqx/data/mnesia`, this app cannot tell which one you meant to
+keep. It logs the names it found and carries on with one of them; set
+`EMQX_NODE__NAME` to the one you want, or use
+[EMQX backup and restore][backup-restore] to merge them.
 
 ## Known issues and limitations
 
@@ -148,6 +170,7 @@ SOFTWARE.
 
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_emqx&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
+[backup-restore]: https://docs.emqx.com/en/emqx/latest/operations/backup-restore.html
 [contributors]: https://github.com/hassio-addons/app-emqx/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons

--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -92,11 +92,13 @@ You do not need to configure anything. If you want a specific name anyway, set
 
 If a hostname change already left you with more than one database directory
 under `/data/emqx/data/mnesia`, this app cannot tell which one you meant to
-keep. It logs the names it found and then falls back to the name matching your
-current hostname, or to `emqx@127.0.0.1` when none of them match. That fallback
-is an empty database, so EMQX will look freshly installed. Set
-`EMQX_NODE__NAME` to the directory you want and restart, or use
-[EMQX backup and restore][backup-restore] to merge them.
+keep. It logs the names it found and then picks one of two ways out. If one of
+them matches your current hostname it uses that, and you get the data in that
+directory. If none of them match it uses `emqx@127.0.0.1`, which is a directory
+that does not exist yet, so EMQX starts empty and looks freshly installed with
+your data untouched beside it. Either way, set `EMQX_NODE__NAME` to the
+directory you want and restart, or use [EMQX backup and restore][backup-restore]
+to merge them.
 
 ## Known issues and limitations
 

--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -5,10 +5,12 @@
 # Runs the EMQX broker
 # ==============================================================================
 declare emqx_host
+declare node_cookie
 declare node_name
 
 readonly default_node_name="emqx@127.0.0.1"
 readonly mnesia_dir="/data/emqx/data/mnesia"
+readonly node_cookie_file="/data/emqx/node.cookie"
 readonly node_name_file="/data/emqx/node.name"
 
 # EMQX keeps its database in a directory named after the node name, and that
@@ -27,7 +29,7 @@ resolve_node_name() {
     if bashio::fs.directory_exists "${mnesia_dir}"; then
         mapfile -t node_dirs < <(
             find "${mnesia_dir}" -mindepth 1 -maxdepth 1 -type d \
-                -name 'emqx@*' -printf '%f\n' | sort
+                -name '*@*' -printf '%f\n' | sort
         )
     fi
 
@@ -56,12 +58,27 @@ resolve_node_name() {
     printf '%s' "${default_node_name}"
 }
 
+# The Erlang cookie guards distribution access, and this app runs with host
+# networking. Deriving it from anything shared, a hostname or the default node
+# name, hands every installation the same secret, so one is drawn per install.
+resolve_node_cookie() {
+    if bashio::fs.file_non_empty "${node_cookie_file}"; then
+        cat "${node_cookie_file}"
+        return
+    fi
+
+    od -vAn -tx1 -N32 /dev/urandom | tr -d ' \n'
+}
+
 bashio::log.info 'Starting EMQX...'
 
 node_name=$(resolve_node_name)
+node_cookie=$(resolve_node_cookie)
+
+(umask 077 && printf '%s' "${node_cookie}" > "${node_cookie_file}")
 
 export EMQX_NODE__NAME="${node_name}"
-export EMQX_NODE__COOKIE="${node_name#*@}"
+export EMQX_NODE__COOKIE="${node_cookie}"
 export EMQX_NODE__DATA_DIR="/data/emqx/data"
 export EMQX_NODE__ETC_DIR="/data/emqx/etc"
 export EMQX_PLUGINS__INSTALL_DIR="/data/emqx/plugins"
@@ -81,11 +98,12 @@ if [[ ! "${EMQX_NODE__NAME}" =~ ^[A-Za-z0-9_.-]+@[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; 
     bashio::exit.nok 'A node name looks like "emqx@127.0.0.1"'
 fi
 
-# The Erlang VM resolves the host part of its own node name at boot. An
-# installation that keeps a name from before a hostname change no longer
-# resolves it, so point the name back at this container.
+# The Erlang distribution resolves the host part of the node name, and without
+# it `emqx ctl` cannot reach the node. A name kept from before a hostname change
+# either does not resolve or, worse, resolves to whatever took the old name, so
+# it is pinned here. /etc/hosts is consulted ahead of DNS.
 emqx_host="${EMQX_NODE__NAME#*@}"
-if ! getent hosts "${emqx_host}" > /dev/null; then
+if [[ ! "${emqx_host}" =~ ^[0-9.]+$ ]]; then
     bashio::log.info "Mapping ${emqx_host} onto 127.0.0.1"
     printf '127.0.0.1\t%s\n' "${emqx_host}" >> /etc/hosts \
         || bashio::log.warning "Could not add ${emqx_host} to /etc/hosts"

--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -4,16 +4,66 @@
 # Home Assistant Community App: EMQX
 # Runs the EMQX broker
 # ==============================================================================
+declare emqx_host
+declare node_name
+
+readonly default_node_name="emqx@127.0.0.1"
+readonly mnesia_dir="/data/emqx/data/mnesia"
+readonly node_name_file="/data/emqx/node.name"
+
+# EMQX keeps its database in a directory named after the node name, and that
+# name used to be derived from the Home Assistant hostname. Renaming the
+# instance therefore left EMQX looking at an empty database, with the old one
+# still on disk but out of reach. The name is resolved once and remembered.
+resolve_node_name() {
+    local -a node_dirs=()
+    local legacy_node_name
+
+    if bashio::fs.file_non_empty "${node_name_file}"; then
+        cat "${node_name_file}"
+        return
+    fi
+
+    if bashio::fs.directory_exists "${mnesia_dir}"; then
+        mapfile -t node_dirs < <(
+            find "${mnesia_dir}" -mindepth 1 -maxdepth 1 -type d \
+                -name 'emqx@*' -printf '%f\n' | sort
+        )
+    fi
+
+    # An existing installation keeps the name its database already carries
+    if [[ "${#node_dirs[@]}" -eq 1 ]]; then
+        printf '%s' "${node_dirs[0]}"
+        return
+    fi
+
+    legacy_node_name="emqx@$(bashio::info.hostname).local"
+
+    if [[ "${#node_dirs[@]}" -gt 1 ]]; then
+        bashio::log.warning "Found ${#node_dirs[@]} EMQX databases in ${mnesia_dir}:"
+        bashio::log.warning "${node_dirs[*]}"
+        bashio::log.warning \
+            "This happens when the Home Assistant hostname changed before."
+        bashio::log.warning \
+            "Set EMQX_NODE__NAME to the one you want to keep using."
+
+        if [[ -d "${mnesia_dir}/${legacy_node_name}" ]]; then
+            printf '%s' "${legacy_node_name}"
+            return
+        fi
+    fi
+
+    printf '%s' "${default_node_name}"
+}
+
 bashio::log.info 'Starting EMQX...'
 
-EMQX_HOST=$(bashio::info.hostname)
+node_name=$(resolve_node_name)
 
-export EMQX_HOST
-export EMQX_NAME="emqx"
-export EMQX_NODE__COOKIE="${EMQX_HOST}"
+export EMQX_NODE__NAME="${node_name}"
+export EMQX_NODE__COOKIE="${node_name#*@}"
 export EMQX_NODE__DATA_DIR="/data/emqx/data"
 export EMQX_NODE__ETC_DIR="/data/emqx/etc"
-export EMQX_NODE__NAME="${EMQX_NAME}@${EMQX_HOST}.local"
 export EMQX_PLUGINS__INSTALL_DIR="/data/emqx/plugins"
 export EMQX_RPC__PORT_DISCOVERY="manual"
 export EMQX_LOG_DIR="/config/log"
@@ -25,6 +75,24 @@ for var in $(bashio::config 'env_vars|keys'); do
     bashio::log.info "Setting ${name} to ${value}"
     export "${name}=${value}"
 done
+
+if [[ ! "${EMQX_NODE__NAME}" =~ ^[A-Za-z0-9_.-]+@[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
+    bashio::log.fatal "Invalid EMQX node name: ${EMQX_NODE__NAME}"
+    bashio::exit.nok 'A node name looks like "emqx@127.0.0.1"'
+fi
+
+# The Erlang VM resolves the host part of its own node name at boot. An
+# installation that keeps a name from before a hostname change no longer
+# resolves it, so point the name back at this container.
+emqx_host="${EMQX_NODE__NAME#*@}"
+if ! getent hosts "${emqx_host}" > /dev/null; then
+    bashio::log.info "Mapping ${emqx_host} onto 127.0.0.1"
+    printf '127.0.0.1\t%s\n' "${emqx_host}" >> /etc/hosts \
+        || bashio::log.warning "Could not add ${emqx_host} to /etc/hosts"
+fi
+
+printf '%s' "${EMQX_NODE__NAME}" > "${node_name_file}"
+bashio::log.info "Using EMQX node name: ${EMQX_NODE__NAME}"
 
 # Set max open file limit to avoid memory allocation issues
 if [ "$(ulimit -Hn)" -gt 524288 ]; then

--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -9,6 +9,7 @@ declare node_cookie
 declare node_name
 
 readonly default_node_name="emqx@127.0.0.1"
+readonly ipv4_octet='(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])'
 readonly mnesia_dir="/data/emqx/data/mnesia"
 readonly node_cookie_file="/data/emqx/node.cookie"
 readonly node_name_file="/data/emqx/node.name"
@@ -103,7 +104,7 @@ fi
 # either does not resolve or, worse, resolves to whatever took the old name, so
 # it is pinned here. /etc/hosts is consulted ahead of DNS.
 emqx_host="${EMQX_NODE__NAME#*@}"
-if [[ ! "${emqx_host}" =~ ^[0-9.]+$ ]]; then
+if [[ ! "${emqx_host}" =~ ^${ipv4_octet}(\.${ipv4_octet}){3}$ ]]; then
     bashio::log.info "Mapping ${emqx_host} onto 127.0.0.1"
     printf '127.0.0.1\t%s\n' "${emqx_host}" >> /etc/hosts \
         || bashio::log.warning "Could not add ${emqx_host} to /etc/hosts"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fixes #161, taking the idea from #164 but not its implementation.

### The problem

EMQX names its database directory after its node name, and this app built that name out of the Home Assistant hostname:

```bash
export EMQX_NODE__NAME="${EMQX_NAME}@${EMQX_HOST}.local"
```

Rename the instance and EMQX starts on a fresh, empty database. The populated one is still on disk under the old name, just out of reach, which reads as data loss to the user. Moving the directory does not recover it either, as #161 found: the old node name is recorded inside the database files, so EMQX starts and then crash loops trying to reach a node that is not there.

### The fix

The node name is resolved once and kept in `/data/emqx/node.name`:

| Situation | Node name |
| --- | --- |
| New installation | `emqx@127.0.0.1` |
| Existing installation, one directory under `data/mnesia` | the name that directory already carries |
| Existing installation, several such directories | logged, with a pointer at `EMQX_NODE__NAME` |
| `EMQX_NODE__NAME` set in `env_vars` | that, always |

Nothing moves for existing users on update, and nothing moves for anyone when the hostname changes afterwards. `EMQX_NODE__NAME` is validated before EMQX gets to fail on it obscurely, and it is only persisted once it passes.

### Why /etc/hosts is touched

Keeping a node name after the hostname moved leaves the host part unresolvable, and that breaks the CLI. Measured, with `emqx@oldhost.local` and no matching hosts entry:

```
$ emqx ctl status
Node 'emqx@oldhost.local' not responding to pings.
```

With the mapping in place:

```
$ emqx ctl status
Node 'emqx@oldhost.local' 5.8.9 is started
```

EMQX itself boots either way; it is only the Erlang distribution that needs somewhere to connect. Worth noting this also fixes the CLI on installations that never renamed anything, since `<hostname>.local` does not resolve inside the container today either.

### Two things removed

- `EMQX_HOST` and `EMQX_NAME` are gone. They are leftovers from the EMQX 4 entrypoint; `grep -r` over both the 5.8.9 and 6.2.3 releases finds no reference to either, and EMQX does not echo them at boot the way it echoes the settings it recognises.
- The cookie follows the node name rather than the hostname, so it stops shifting when the instance is renamed. For a single node it only gates `emqx ctl`, which reads the same value.

### Where this differs from #164

- **No hardcoded cookie.** #164 sets `EMQX_NODE__COOKIE="addon_emqx"`, the same value on every installation. This app runs with `host_network: true`, so the Erlang distribution port is on the LAN, and a cookie shared across every install is a worse position than a per-install one. Deriving it from the node name keeps that property.
- **The name is persisted after the user's `env_vars` are applied**, not before, so `/data/emqx/node.name` records what EMQX actually ran with.
- **`/data/emqx/node.name`, not `/data/emqx/etc/node.name`.** The latter is EMQX's own `node.etc_dir`; better not to leave a file of ours in it.
- **No CI harness.** #164 adds 238 lines under `.github/scripts` plus a job wired into `ci.yaml`, which no other app in the family carries, and which would need rewriting against the `app-ci` workflow from #168 anyway. The equivalent scenarios were run locally instead, listed below.

### Verified

Seven scenarios, running the real `run` script inside the built image with only `bashio::info.hostname` and `bashio::config` stubbed, and `exec` intercepted:

| Scenario | Result |
| --- | --- |
| Fresh install | `emqx@127.0.0.1`, persisted |
| One `mnesia` dir `emqx@oldhost.local`, hostname now `newhost` | keeps `emqx@oldhost.local`, maps it in `/etc/hosts` |
| `node.name` already present | wins over discovery |
| Two `mnesia` dirs, no legacy match | warns, falls back to `emqx@127.0.0.1` |
| Two `mnesia` dirs, one matching the hostname | warns, keeps the matching one |
| `EMQX_NODE__NAME` set by the user | wins, persisted, mapped |
| `EMQX_NODE__NAME` invalid | two FATAL lines, exits 1, nothing persisted |

Plus the two live `emqx ctl` runs quoted above, and Shellcheck clean under `SHELLCHECK_OPTS=-s bash`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #161. Reworks the `run` script half of #164, credit to its author for the approach.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node names are now selected and saved consistently across restarts.
  * New installations use `emqx@127.0.0.1` by default, while existing installations retain their current identity.
  * A random Erlang cookie is generated and persisted when none is configured.
  * Node names can be explicitly configured and are validated at startup.
  * Improved handling and warnings for multiple database directories after hostname changes.

* **Documentation**
  * Added guidance on node naming, persistence, fallback behavior, and backup and restore procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->