### PR TITLE
Correct the license label and document the v5 to v6 session loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ website, this app runs EMQX in a fully local, self-hosted environment.
 
 As of version 5.9.0, EMQX is no longer open source; it is licensed under the
 [Business Source License 1.1][emqx-license]. The build shipped here carries the
-EMQX Community License, which is free of charge and allows running a single
-node, which is exactly what this app does. Clustering requires a commercial
-license.
+EMQX Community License, which is free of charge, does not expire, and covers a
+single node with up to 10 million concurrent sessions. Clustering is the part
+that needs a commercial license, and this app has never clustered.
 
 [:books: Read the full app documentation][docs]
 

--- a/emqx/.README.j2
+++ b/emqx/.README.j2
@@ -24,9 +24,9 @@ website, this app runs EMQX in a fully local, self-hosted environment.
 
 As of version 5.9.0, EMQX is no longer open source; it is licensed under the
 [Business Source License 1.1][emqx-license]. The build shipped here carries the
-EMQX Community License, which is free of charge and allows running a single
-node, which is exactly what this app does. Clustering requires a commercial
-license.
+EMQX Community License, which is free of charge, does not expire, and covers a
+single node with up to 10 million concurrent sessions. Clustering is the part
+that needs a commercial license, and this app has never clustered.
 
 ![EMQX in the Home Assistant Frontend][screenshot]
 

--- a/emqx/DOCS.md
+++ b/emqx/DOCS.md
@@ -14,9 +14,9 @@ website, this app runs EMQX in a fully local, self-hosted environment.
 
 As of version 5.9.0, EMQX is no longer open source; it is licensed under the
 [Business Source License 1.1][emqx-license]. The build shipped here carries the
-EMQX Community License, which is free of charge and allows running a single
-node, which is exactly what this app does. Clustering requires a commercial
-license.
+EMQX Community License, which is free of charge, does not expire, and covers a
+single node with up to 10 million concurrent sessions. Clustering is the part
+that needs a commercial license, and this app has never clustered.
 
 ## Installation
 
@@ -97,8 +97,15 @@ documentation:
 
 This app has moved from EMQX 5.8.9 to EMQX 6. EMQX 6 reads the existing data
 directory in place, so dashboard users, authentication records, rules and
-retained messages carry over on the first start, and there is nothing to do
-beyond updating the app.
+retained messages carry over on the first start.
+
+One thing does not carry over. EMQX
+[does not preserve durable session state][rolling-upgrades] across the version 5
+to version 6 boundary: clients holding one reconnect into a clean session, and
+the messages queued for them while they were away are gone. This only affects
+you if you turned durable sessions on yourself through
+`EMQX_DURABLE_SESSIONS__ENABLE`, since EMQX ships with them disabled. Ordinary
+retained messages are unaffected.
 
 A major version change is still a good moment for a backup. Downgrading back to
 EMQX 5 is not something EMQX supports, so take one before updating if you want a
@@ -175,5 +182,6 @@ SOFTWARE.
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/app-emqx/issues
 [reddit]: https://reddit.com/r/homeassistant
+[rolling-upgrades]: https://docs.emqx.com/en/emqx/latest/deploy/rolling-upgrades.html
 [releases]: https://github.com/hassio-addons/app-emqx/releases
 [semver]: https://semver.org/spec/v2.0.0.html

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -53,7 +53,7 @@ LABEL \
     io.hass.description="${BUILD_DESCRIPTION}" \
     org.opencontainers.image.vendor="Home Assistant Community Apps" \
     org.opencontainers.image.authors="Franck Nijhof <opensource@frenck.dev>" \
-    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.licenses="MIT AND BUSL-1.1" \
     org.opencontainers.image.url="https://frenck.dev/home-assistant-apps" \
     org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Follow up to #170, which merged before the CodeRabbit review on it was addressed. Three findings, all documentation and metadata; no behaviour changes.

### The OCI license label

`org.opencontainers.image.licenses` still said `MIT` while the image now bundles BSL licensed EMQX. OCI defines that field for the licenses of the contained software, so it now reads `MIT AND BUSL-1.1`.

Worth flagging: the review proposed `BSL-1.1`, which is not an SPDX identifier at all. `BSL-1.0` is the **Boost** Software License, and the Business Source License 1.1 is `BUSL-1.1`. Taking the suggestion literally would have swapped one wrong label for another.

### Durable sessions do not survive the upgrade

The upgrade section claimed everything carries over. It does not. EMQX documents that [durable session state is lost across the version 5 to version 6 boundary][rolling-upgrades]:

> Durable session states will be lost after upgrading from v5 to v6. After clients reconnect, the sessions created in the new nodes will appear to be clean.

The blast radius is small, and the review did not mention this part: `durable_sessions.enable` defaults to `false` in 5.8.9, so only someone who turned it on through `EMQX_DURABLE_SESSIONS__ENABLE` is affected. Ordinary retained messages are untouched. Both facts are now in DOCS.md rather than just the caveat.

### The Community License terms were half stated

The docs gave the single node and clustering terms but stopped there, which leaves the obvious question unanswered. They now also say it does not expire and covers 10 million concurrent sessions, the two facts that establish nothing is actually gated for a Home Assistant user. Applied to all three copies of the paragraph.

### Verified

Prettier and Hadolint clean. Nothing here touches the build, the run script or the image contents beyond one LABEL value.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows #170.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
[rolling-upgrades]: https://docs.emqx.com/en/emqx/latest/deploy/rolling-upgrades.html
